### PR TITLE
Add null checks on API

### DIFF
--- a/src/main/java/yapion/serializing/YAPIONDeserializer.java
+++ b/src/main/java/yapion/serializing/YAPIONDeserializer.java
@@ -4,6 +4,7 @@
 
 package yapion.serializing;
 
+import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import yapion.annotations.deserialize.YAPIONDeserializeType;
@@ -79,7 +80,7 @@ public final class YAPIONDeserializer {
      * @param yapionObject to deserialize
      * @return Object from the YAPIONObject to deserialize
      */
-    public static Object deserialize(YAPIONObject yapionObject) {
+    public static Object deserialize(@NonNull YAPIONObject yapionObject) {
         return deserialize(yapionObject, "");
     }
 
@@ -90,7 +91,7 @@ public final class YAPIONDeserializer {
      * @param state the state for deserialization
      * @return Object from the YAPIONObject to deserialize
      */
-    public static Object deserialize(YAPIONObject yapionObject, String state) {
+    public static Object deserialize(@NonNull YAPIONObject yapionObject, String state) {
         return new YAPIONDeserializer(yapionObject, state).parse().getObject();
     }
 
@@ -100,12 +101,12 @@ public final class YAPIONDeserializer {
      * @param yapionObject to deserialize
      * @param state the state for deserialization
      */
-    public YAPIONDeserializer(YAPIONObject yapionObject, String state) {
+    public YAPIONDeserializer(@NonNull YAPIONObject yapionObject, String state) {
         stateManager = new StateManager(state);
         this.yapionObject = yapionObject;
     }
 
-    private YAPIONDeserializer(YAPIONObject yapionObject, YAPIONDeserializer yapionDeserializer) {
+    private YAPIONDeserializer(@NonNull YAPIONObject yapionObject, YAPIONDeserializer yapionDeserializer) {
         this.yapionObject = yapionObject;
         this.stateManager = yapionDeserializer.stateManager;
         this.pointerMap = yapionDeserializer.pointerMap;

--- a/src/main/java/yapion/serializing/YAPIONSerializer.java
+++ b/src/main/java/yapion/serializing/YAPIONSerializer.java
@@ -4,6 +4,7 @@
 
 package yapion.serializing;
 
+import lombok.NonNull;
 import yapion.annotations.deserialize.YAPIONLoadExclude;
 import yapion.annotations.serialize.YAPIONSaveExclude;
 import yapion.hierarchy.types.YAPIONType;
@@ -38,7 +39,7 @@ public final class YAPIONSerializer {
      * @param object to serialize
      * @return YAPIONObject from the object to serialize
      */
-    public static YAPIONObject serialize(Object object) {
+    public static YAPIONObject serialize(@NonNull() Object object) {
         return serialize(object, "");
     }
 
@@ -49,7 +50,7 @@ public final class YAPIONSerializer {
      * @param state the state for serialization
      * @return YAPIONObject from the object to serialize
      */
-    public static YAPIONObject serialize(Object object, String state) {
+    public static YAPIONObject serialize(@NonNull Object object, String state) {
         return new YAPIONSerializer(object, state).parse().getYAPIONObject();
     }
 
@@ -59,12 +60,12 @@ public final class YAPIONSerializer {
      * @param object to serialize
      * @param state the state for serialization
      */
-    public YAPIONSerializer(Object object, String state) {
+    public YAPIONSerializer(@NonNull Object object, String state) {
         stateManager = new StateManager(state);
         this.object = object;
     }
 
-    private YAPIONSerializer(Object object, YAPIONSerializer yapionSerializer) {
+    private YAPIONSerializer(@NonNull Object object, YAPIONSerializer yapionSerializer) {
         this.object = object;
         this.stateManager = yapionSerializer.stateManager;
         this.pointerMap = yapionSerializer.pointerMap;

--- a/src/test/java/yapion/serializing/YAPIONDeserializerTest.java
+++ b/src/test/java/yapion/serializing/YAPIONDeserializerTest.java
@@ -43,4 +43,14 @@ public class YAPIONDeserializerTest {
         assertThat(object, is(new TestEnum()));
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testNPECheck() {
+        YAPIONDeserializer.deserialize(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNPECheckState() {
+        YAPIONDeserializer.deserialize(null, "some state");
+    }
+
 }

--- a/src/test/java/yapion/serializing/YAPIONSerializerTest.java
+++ b/src/test/java/yapion/serializing/YAPIONSerializerTest.java
@@ -70,4 +70,14 @@ public class YAPIONSerializerTest {
         assertThat(YAPIONParser.parse(yapionObject.toString()).toString(), is(yapionObject.toString()));
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testNPECheck() {
+        YAPIONSerializer.serialize(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNPECheckState() {
+        YAPIONSerializer.serialize(null, "some state");
+    }
+
 }


### PR DESCRIPTION
Hi yoyosource

I suggest adding some explicit null checks directly to public API methods to prevent NPEs from being thrown from the internal code.

Best regards,
Torsten
