### PR TITLE
Enable objects as root objects that do not contain save annotations

### DIFF
--- a/src/main/java/yapion/exceptions/serializing/YAPIONDeserializerException.java
+++ b/src/main/java/yapion/exceptions/serializing/YAPIONDeserializerException.java
@@ -1,0 +1,27 @@
+package yapion.exceptions.serializing;
+
+import yapion.exceptions.YAPIONException;
+
+public class YAPIONDeserializerException extends YAPIONException {
+
+    public YAPIONDeserializerException() {
+        super();
+    }
+
+    public YAPIONDeserializerException(String message) {
+        super(message);
+    }
+
+    public YAPIONDeserializerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public YAPIONDeserializerException(Throwable cause) {
+        super(cause);
+    }
+
+    public YAPIONDeserializerException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/src/main/java/yapion/exceptions/serializing/YAPIONSerializerException.java
+++ b/src/main/java/yapion/exceptions/serializing/YAPIONSerializerException.java
@@ -1,0 +1,27 @@
+package yapion.exceptions.serializing;
+
+import yapion.exceptions.YAPIONException;
+
+public class YAPIONSerializerException extends YAPIONException {
+
+    public YAPIONSerializerException() {
+        super();
+    }
+
+    public YAPIONSerializerException(String message) {
+        super(message);
+    }
+
+    public YAPIONSerializerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public YAPIONSerializerException(Throwable cause) {
+        super(cause);
+    }
+
+    public YAPIONSerializerException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/src/main/java/yapion/serializing/YAPIONDeserializer.java
+++ b/src/main/java/yapion/serializing/YAPIONDeserializer.java
@@ -13,6 +13,8 @@ import yapion.annotations.object.YAPIONObjenesis;
 import yapion.annotations.object.YAPIONPostDeserialization;
 import yapion.annotations.object.YAPIONPreDeserialization;
 import yapion.annotations.serialize.YAPIONSaveExclude;
+import yapion.exceptions.serializing.YAPIONDeserializerException;
+import yapion.exceptions.serializing.YAPIONSerializerException;
 import yapion.exceptions.utils.YAPIONReflectionException;
 import yapion.hierarchy.typegroups.YAPIONAnyType;
 import yapion.hierarchy.types.YAPIONArray;
@@ -233,7 +235,7 @@ public final class YAPIONDeserializer {
         try {
             Class<?> clazz = Class.forName(type);
             if (!stateManager.is(clazz).load) {
-                return this;
+                throw new YAPIONDeserializerException("No suitable deserializer found, maybe class (" + object.getClass().getTypeName() + ") is missing YAPION annotations");
             }
 
             if (clazz.getDeclaredAnnotation(YAPIONObjenesis.class) != null) {

--- a/src/main/java/yapion/serializing/YAPIONSerializer.java
+++ b/src/main/java/yapion/serializing/YAPIONSerializer.java
@@ -7,6 +7,7 @@ package yapion.serializing;
 import lombok.NonNull;
 import yapion.annotations.deserialize.YAPIONLoadExclude;
 import yapion.annotations.serialize.YAPIONSaveExclude;
+import yapion.exceptions.serializing.YAPIONSerializerException;
 import yapion.hierarchy.types.YAPIONType;
 import yapion.hierarchy.typegroups.YAPIONAnyType;
 import yapion.hierarchy.types.YAPIONVariable;
@@ -118,11 +119,8 @@ public final class YAPIONSerializer {
 
     @SuppressWarnings({"java:S3740", "java:S3011", "java:S1117", "unchecked"})
     private YAPIONSerializer parseObject(Object object) {
-        if (!stateManager.is(object).save) {
-            return this;
-        }
         if (object.getClass().getSimpleName().contains("$")) {
-            return this;
+            throw new YAPIONSerializerException("Simple class name (" + object.getClass().getTypeName() + ") is not allowed to contain '$'");
         }
 
         String type = object.getClass().getTypeName();
@@ -133,6 +131,10 @@ public final class YAPIONSerializer {
         if (serializer != null && !serializer.empty()) {
             this.yapionObject = (YAPIONObject) serializer.serialize(object, this);
             return this;
+        }
+
+        if (!stateManager.is(object).save) {
+            throw new YAPIONSerializerException("No suitable serializer found, maybe class (" + object.getClass().getTypeName() + ") is missing YAPION annotations");
         }
 
         YAPIONObject yapionObject = new YAPIONObject();

--- a/src/test/java/yapion/annotation/AnnotationFieldTypeTest.java
+++ b/src/test/java/yapion/annotation/AnnotationFieldTypeTest.java
@@ -1,32 +1,45 @@
 package yapion.annotation;
 
 import org.junit.Test;
+import yapion.exceptions.serializing.YAPIONSerializerException;
 import yapion.hierarchy.types.YAPIONObject;
 import yapion.serializing.YAPIONSerializer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static yapion.annotation.AnnotationTestObjects.*;
+import static yapion.annotation.AnnotationTestObjects.FieldTypeTest1;
+import static yapion.annotation.AnnotationTestObjects.FieldTypeTest2;
 
 public class AnnotationFieldTypeTest {
 
-    @Test
-    public void testField() {
-        YAPIONObject yapionObject = YAPIONSerializer.serialize(new FieldTypeTest(), "field");
-        assertThat(yapionObject, is(nullValue()));
+    @Test(expected = YAPIONSerializerException.class)
+    public void testSerializeStateNotDefinedAsClassContext() {
+        // No context with name "field" defined in @YAPIONData or @YAPIONSave
+        YAPIONObject yapionObject = YAPIONSerializer.serialize(new FieldTypeTest1(), "field");
     }
 
     @Test
-    public void testFieldOther() {
-        YAPIONObject yapionObject = YAPIONSerializer.serialize(new FieldTypeTest(), "fieldOther");
-        assertThat(yapionObject.toYAPIONString(), is("{@type(yapion.annotation.AnnotationTestObjects$FieldTypeTest)s(FieldType)}"));
+    public void testSerializeStateDefinedAsClassContextInSave() {
+        // A context with name "fieldOther" defined in @YAPIONSave (but not in @YAPIONData, but this does not matter):
+        // Field IS serialized
+        YAPIONObject yapionObject = YAPIONSerializer.serialize(new FieldTypeTest1(), "fieldOther");
+        assertThat(yapionObject.toYAPIONString(), is("{@type(yapion.annotation.AnnotationTestObjects$FieldTypeTest1)s(some-string)}"));
     }
 
     @Test
-    public void testType() {
-        YAPIONObject yapionObject = YAPIONSerializer.serialize(new FieldTypeTest(), "type");
-        assertThat(yapionObject.toYAPIONString(), is("{@type(yapion.annotation.AnnotationTestObjects$FieldTypeTest)s(FieldType)}"));
+    public void testSerializeStateDefinedAsClassContextInDataOverwriteFieldAnnotation() {
+        // A context with name "type" defined in @YAPIONData (but not in @YAPIONSave, but this does not matter):
+        // Field IS serialized
+        YAPIONObject yapionObject = YAPIONSerializer.serialize(new FieldTypeTest1(), "type");
+        assertThat(yapionObject.toYAPIONString(), is("{@type(yapion.annotation.AnnotationTestObjects$FieldTypeTest1)s(some-string)}"));
+    }
+
+    @Test
+    public void testSerializeStateDefinedAsClassContextInSaveNotOverwritingFieldAnnotation() {
+        // A context with name "other" defined in @YAPIONSave, but not in @YAPIONField:
+        // Field is NOT serialized
+        YAPIONObject yapionObject = YAPIONSerializer.serialize(new FieldTypeTest2(), "other");
+        assertThat(yapionObject.toYAPIONString(), is("{@type(yapion.annotation.AnnotationTestObjects$FieldTypeTest2)}"));
     }
 
 }

--- a/src/test/java/yapion/annotation/AnnotationTestObjects.java
+++ b/src/test/java/yapion/annotation/AnnotationTestObjects.java
@@ -62,10 +62,18 @@ public class AnnotationTestObjects {
 
     @YAPIONData(context = "type")
     @YAPIONSave(context = "fieldOther")
-    public static class FieldTypeTest {
+    public static class FieldTypeTest1 {
 
-        @YAPIONField(context = {"field", "fieldOther"})
-        private String s = "FieldType";
+        @YAPIONField(context = {"fieldOther"})
+        private String s = "some-string";
+
+    }
+
+    @YAPIONSave(context = "other")
+    public static class FieldTypeTest2 {
+
+        @YAPIONField(context = {"fieldOther"})
+        private String s = "some-string";
 
     }
 

--- a/src/test/java/yapion/serializing/YAPIONSerializerTest.java
+++ b/src/test/java/yapion/serializing/YAPIONSerializerTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import yapion.hierarchy.types.YAPIONObject;
 import yapion.parser.YAPIONParser;
 
+import java.util.ArrayList;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static yapion.serializing.YAPIONTestObjects.*;
@@ -78,6 +80,14 @@ public class YAPIONSerializerTest {
     @Test(expected = NullPointerException.class)
     public void testNPECheckState() {
         YAPIONSerializer.serialize(null, "some state");
+    }
+
+    @Test
+    public void testInternalSerializer() {
+        // It should be possible to use objects as root objects for which
+        // an internal serializer exists which returns a YAPIONObject.
+        YAPIONObject yapionObject = YAPIONSerializer.serialize(new ArrayList<String>());
+        assertThat(yapionObject.toString(), is("{@type(java.util.ArrayList)values[]}"));
     }
 
 }


### PR DESCRIPTION
Hi yoyosource

I tried to serialize a list (ArrayList<>()) containing objects annotated with @YAPIONData and got a NPE.

After some debugging I realized that this problem is not limited to collection types but to any root type for which an internal serializer exists that returns a YAPION object.

This change makes it possible to use objects as root objects for which an internal serializer exists that returns a YAPIONObject.

Important: enums now need special treatment. I hope it is ok if enum values are now always serialized, if they are not explicitly excluded.

Best regards,
Torsten