### PR TITLE
Add cascading feature to propagate YAPIONData annotation to instance properties and their properties, too.

### DIFF
--- a/src/main/java/yapion/annotations/object/YAPIONData.java
+++ b/src/main/java/yapion/annotations/object/YAPIONData.java
@@ -28,4 +28,9 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE})
 public @interface YAPIONData {
     String[] context() default {};
+
+    /**
+     * Cascade this annotation to instance properties / objects and their properties, too.
+     */
+    boolean cascading() default false;
 }

--- a/src/main/java/yapion/serializing/ContextManager.java
+++ b/src/main/java/yapion/serializing/ContextManager.java
@@ -113,6 +113,7 @@ public final class ContextManager {
         return is(object.getClass());
     }
 
+    @SuppressWarnings({"java:S3011"})
     YAPIONInfo is(Object object, Field field) {
         is(object.getClass());
 

--- a/src/main/java/yapion/serializing/ContextManager.java
+++ b/src/main/java/yapion/serializing/ContextManager.java
@@ -90,7 +90,12 @@ public final class ContextManager {
         if (is(clazz.getDeclaredAnnotation(YAPIONSaveExclude.class))) globalSave = false;
         globalSave = is(clazz.getDeclaredAnnotation(YAPIONSave.class));
 
-        yapionData = clazz.getDeclaredAnnotation(YAPIONData.class);
+        if (yapionData == null) {
+            yapionData = clazz.getDeclaredAnnotation(YAPIONData.class);
+        }
+        if (!isCascading()) {
+            yapionData = clazz.getDeclaredAnnotation(YAPIONData.class);
+        }
         if (yapionData != null) {
             boolean yapionDataBoolean = is(yapionData);
             globalLoad = globalLoad || yapionDataBoolean;
@@ -100,11 +105,14 @@ public final class ContextManager {
         return new YAPIONInfo(globalLoad, globalSave, yapionData != null && globalLoad);
     }
 
+    boolean isCascading() {
+        return yapionData != null && yapionData.cascading();
+    }
+
     YAPIONInfo is(Object object) {
         return is(object.getClass());
     }
 
-    @SuppressWarnings({"java:S3011"})
     YAPIONInfo is(Object object, Field field) {
         is(object.getClass());
 

--- a/src/main/java/yapion/serializing/YAPIONDeserializer.java
+++ b/src/main/java/yapion/serializing/YAPIONDeserializer.java
@@ -303,7 +303,7 @@ public final class YAPIONDeserializer {
         try {
             Class<?> clazz = Class.forName(type);
             if (!contextManager.is(clazz).load) {
-                throw new YAPIONDeserializerException("No suitable deserializer found, maybe class (" + object.getClass().getTypeName() + ") is missing YAPION annotations");
+                throw new YAPIONDeserializerException("No suitable deserializer found, maybe class (" + type + ") is missing YAPION annotations");
             }
 
             object = SerializeManager.getObjectInstance(clazz, type, contextManager);

--- a/src/main/java/yapion/serializing/YAPIONDeserializer.java
+++ b/src/main/java/yapion/serializing/YAPIONDeserializer.java
@@ -151,7 +151,11 @@ public final class YAPIONDeserializer {
 
     private YAPIONDeserializer(@NonNull YAPIONObject yapionObject, YAPIONDeserializer yapionDeserializer) {
         this.yapionObject = yapionObject;
-        this.contextManager = yapionDeserializer.contextManager;
+        if (yapionDeserializer.contextManager.isCascading()) {
+            this.contextManager = yapionDeserializer.contextManager;
+        } else {
+            this.contextManager = new ContextManager(yapionDeserializer.contextManager.get());
+        }
         this.pointerMap = yapionDeserializer.pointerMap;
         this.typeReMapper = yapionDeserializer.typeReMapper;
         this.deserializeResult = yapionDeserializer.deserializeResult;

--- a/src/main/java/yapion/serializing/YAPIONSerializer.java
+++ b/src/main/java/yapion/serializing/YAPIONSerializer.java
@@ -64,7 +64,11 @@ public final class YAPIONSerializer {
 
     private YAPIONSerializer(@NonNull Object object, YAPIONSerializer yapionSerializer) {
         this.object = object;
-        this.contextManager = yapionSerializer.contextManager;
+        if (yapionSerializer.contextManager.isCascading()) {
+            this.contextManager = yapionSerializer.contextManager;
+        } else {
+            this.contextManager = new ContextManager(yapionSerializer.contextManager.get());
+        }
         this.pointerMap = yapionSerializer.pointerMap;
     }
 

--- a/src/main/java/yapion/serializing/serializer/object/other/EnumSerializer.java
+++ b/src/main/java/yapion/serializing/serializer/object/other/EnumSerializer.java
@@ -6,6 +6,7 @@ package yapion.serializing.serializer.object.other;
 
 import yapion.annotations.deserialize.YAPIONLoadExclude;
 import yapion.annotations.serialize.YAPIONSaveExclude;
+import yapion.exceptions.serializing.YAPIONDeserializerException;
 import yapion.hierarchy.typegroups.YAPIONAnyType;
 import yapion.hierarchy.types.YAPIONObject;
 import yapion.hierarchy.types.YAPIONValue;
@@ -45,10 +46,12 @@ public class EnumSerializer implements InternalSerializer<Enum<?>> {
         String enumType = yapionObject.getValue("value", "").get();
         int ordinal = -1;
         if (yapionObject.getValue("ordinal", 0) != null) {
-            ordinal = yapionObject.getValue("ordinal", 0).get();;
+            ordinal = yapionObject.getValue("ordinal", 0).get();
         }
         try {
-            if (!Class.forName(type).isEnum()) return null;
+            if (!Class.forName(type).isEnum()) {
+                throw new YAPIONDeserializerException("Class " + type + " is not an enum");
+            }
             Enum<?>[] enums = (Enum<?>[]) Class.forName(type).getEnumConstants();
             if (ordinal >= 0 && ordinal < enums.length && enums[ordinal].name().equals(enumType)) {
                 return enums[ordinal];
@@ -59,10 +62,11 @@ public class EnumSerializer implements InternalSerializer<Enum<?>> {
                     return e;
                 }
             }
+            throw new YAPIONDeserializerException("Enum element not found: " + type + "[" + enumType + "]");
+
         } catch (ClassNotFoundException e) {
-            // Ignored
+            throw new YAPIONDeserializerException("Class not found: " + type);
         }
-        return null;
     }
 
 }

--- a/src/main/java/yapion/serializing/serializer/object/other/UUIDSerializer.java
+++ b/src/main/java/yapion/serializing/serializer/object/other/UUIDSerializer.java
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// YAPION
+// Copyright (C) 2019,2020 yoyosource
+
 package yapion.serializing.serializer.object.other;
 
 import yapion.annotations.deserialize.YAPIONLoadExclude;

--- a/src/test/java/yapion/serializing/YAPIONDeserializerTest.java
+++ b/src/test/java/yapion/serializing/YAPIONDeserializerTest.java
@@ -1,6 +1,7 @@
 package yapion.serializing;
 
 import org.junit.Test;
+import yapion.exceptions.serializing.YAPIONDeserializerException;
 import yapion.parser.YAPIONParser;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,6 +44,21 @@ public class YAPIONDeserializerTest {
         assertThat(object, is(new TestEnum()));
     }
 
+    @Test(expected = YAPIONDeserializerException.class)
+    public void testEnumClassNotFound() {
+        YAPIONDeserializer.deserialize(YAPIONParser.parse("{@type(yapion.serializing.YAPIONTestObjects$TestEnum)test1{@type(java.lang.Enum)@enum(yapion.serializing.YAPIONTestObjects$Unknown)value(Hello)ordinal(0)}}"));
+    }
+
+    @Test(expected = YAPIONDeserializerException.class)
+    public void testEnumClassNoEnum() {
+        YAPIONDeserializer.deserialize(YAPIONParser.parse("{@type(yapion.serializing.YAPIONTestObjects$TestEnum)test1{@type(java.lang.Enum)@enum(yapion.serializing.YAPIONTestObjects$TestPrimitive)value(Hello)ordinal(0)}}"));
+    }
+
+    @Test(expected = YAPIONDeserializerException.class)
+    public void testEnumElementNotFound() {
+        YAPIONDeserializer.deserialize(YAPIONParser.parse("{@type(yapion.serializing.YAPIONTestObjects$TestEnum)test1{@type(java.lang.Enum)@enum(yapion.serializing.YAPIONTestObjects$EnumerationTest)value(NotHello)ordinal(0)}}"));
+    }
+
     @Test(expected = NullPointerException.class)
     public void testNPECheck() {
         YAPIONDeserializer.deserialize(null);
@@ -51,6 +67,12 @@ public class YAPIONDeserializerTest {
     @Test(expected = NullPointerException.class)
     public void testNPECheckState() {
         YAPIONDeserializer.deserialize(null, "some state");
+    }
+
+    @Test(expected = YAPIONDeserializerException.class)
+    public void testDeserializerMissingLoadAnnotation() {
+        // Resolved class has no Load annotation
+        Object object = YAPIONDeserializer.deserialize(YAPIONParser.parse("{@type(yapion.serializing.YAPIONTestObjects$NoAnnotations)}"));
     }
 
 }

--- a/src/test/java/yapion/serializing/YAPIONTestObjects.java
+++ b/src/test/java/yapion/serializing/YAPIONTestObjects.java
@@ -122,6 +122,8 @@ public class YAPIONTestObjects {
 
     }
 
+    public static class NoAnnotations {}
+
     static String getUserHome() {
         return System.getProperty("user.home");
     }


### PR DESCRIPTION
Hi!

Using YAPION in a legacy project makes it annoying to add the YAPIONData annotation to every class used in a complex and nested object tree.

Also there may be situations where it is not possible to change the source of used classes because they are part of an external library or because you do not have the source of these classes at all.

My idea is to add a flag to the YAPIONData annotation to just cascade the annotation to all classes used as properties / instance variables in an object and also to their children (properties / instance variables), too, and deeper.

During implementing this feature and using YAPION in one of my projects I found a problem in the enum code returning null in case of errors. I suggest using a specific exception instead. To be sure, everything works as before and to check the new exception I added some tests, too. Hope it's okay to include this change in this PR.

I am looking forward to your feedback
Torsten