### PR TITLE
fix: empty catch clauses may hide exceptions

### DIFF
--- a/src/main/java/yapion/serializing/GeneratedSerializerLoader.java
+++ b/src/main/java/yapion/serializing/GeneratedSerializerLoader.java
@@ -89,6 +89,7 @@ public class GeneratedSerializerLoader {
             SerializeManager.add(serializerClass);
             return true;
         } catch (ClassNotFoundException e) {
+            log.error("Error trying to load via 'inner' class identifier", e)
         }
         log.debug("Trying to load via className and Serializer appended");
         try {

--- a/src/test/java/yapion/DeprecationList.java
+++ b/src/test/java/yapion/DeprecationList.java
@@ -74,7 +74,7 @@ public class DeprecationList {
                         System.out.println();
                     }
                 } catch (ClassNotFoundException e) {
-
+                    System.err.println(e.message); // It may be better to make use of a more robust logging solution like logback.
                 }
             }
 


### PR DESCRIPTION
Fixing a few empty catch clauses which might hide exceptions.